### PR TITLE
Loosen dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-lightgbm==2.1.1
-matplotlib==2.1.2
-seaborn==0.8.1
-numpy==1.14.5
-pandas==0.23.1
-scikit-learn==0.19.1
+lightgbm>=2.1.1
+matplotlib>=2.1.2
+seaborn>=0.8.1
+numpy>=1.14.5
+pandas>=0.23.1
+scikit-learn>=0.19.1
 


### PR DESCRIPTION
I can't currently install this library without sending pull requests to
3-5 other open source libraries that require later versions of these
dependencies. For example, this is a very old version of Pandas which
I'd like to upgrade but I can't because this library pins it.

The recommendation is to keep libraries loosely specified. You should
have very few dependencies and have very wide ranges of acceptable
versions. For applications and deployments, you want to pin down
dependency versions very specifically to reduce nondeterminism.
Frequently we'll use `pip freeze > requirements.txt` to do that. But
when we do that sort off thing with libraries it results in these
situations, dependency hell, where you can't arrive at a valid
installation.